### PR TITLE
Allow configuration of copy flags

### DIFF
--- a/deploy_settings
+++ b/deploy_settings
@@ -25,3 +25,9 @@ WEBROOT_SYMLINK_NAME=current
 
 # DRUSH_CMD is your local path to the drush binary.
 DRUSH_CMD=/bin/drush
+
+# COPY_FLAGS defines flags passed to 'cp' when deploying a release directory.
+# Generally you don't want to preserve timestamps.
+# Default is for Linux. BSD wants:
+# COPY_FLAGS="-R"
+COPY_FLAGS="-dr --preserve=mode,ownership,links,xattr"

--- a/site_deploy.sh
+++ b/site_deploy.sh
@@ -189,7 +189,7 @@ then
 fi
 
 # Copy base git clone to target directory
-cp -dr --preserve=mode,ownership,context,links,xattr $GIT_DIR $TARGET_DIR
+cp $COPY_FLAGS $GIT_DIR $TARGET_DIR
 
 # Touch target dir so it has a valid timestamp for the deployment.
 touch $TARGET_DIR


### PR DESCRIPTION
This allows configuration of the flags passed to the ```cp``` command in ```site_deploy.sh```